### PR TITLE
Add support for different data input to the loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Ruby
+name: CI
 
 on:
   push:

--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -1,0 +1,41 @@
+name: Update Changelog on Merge to Main
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  update_changelog:
+    if: github.event.pull_request.merged == true && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.0'
+        bundler-cache: true
+
+    - name: Install Dependencies
+      run: bundle install
+
+    - name: Generate Changelog
+      run: |
+        bundle exec github_changelog_generator \
+          --user ${{ github.repository_owner }} \
+          --project ${{ github.event.repository.name }} \
+          --token ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Commit Changelog
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git add CHANGELOG.md
+        git commit -m "Update CHANGELOG.md for PR #${{ github.event.pull_request.number }}"
+        git push origin main

--- a/README.md
+++ b/README.md
@@ -25,16 +25,25 @@ bundle install
 ```ruby
 require 'flexi/json'
 
-# File path to the JSON data
-Flexi::Json::Run.new("some/path/to/file.json").search("john")
+# Load a json data from a local file
+flexi_json = Flexi::Json::Run.new("some/path/to/file.json")
+
+# Load a raw json data
+flexi_json = Flexi::Json::Run.new("{\"name\":\"John\",\"address\":\"Sydney Australia\"}")
+
+# Load a json data from aurl
+flexi_json = Flexi::Json::Run.new("https://raw.githubusercontent.com/GD-Personal/flexi-json/main/spec/data/dataset.json")
+
+# Search for data
+flexi_json.search("john")
 
 # Or filter it by your chosen key e.g first_name
-Flexi::Json::Run.new("some/path/to/file.json").search("john", "first_name")
-Flexi::Json::Run.new("some/path/to/file.json").search("john", "first_name,email")
+flexi_json.search("john", "first_name")
+flexi_json.search("john", "first_name,email")
 
 # Find duplicate emails
-Flexi::Json::Run.new("some/path/to/file.json").find_duplicates("email")
-Flexi::Json::Run.new("some/path/to/file.json").find_duplicates("email,full_name")
+flexi_json.find_duplicates("email")
+flexi_json.find_duplicates("email,full_name")
 ```
 
 ## TODOS

--- a/README.md
+++ b/README.md
@@ -48,10 +48,8 @@ flexi_json.find_duplicates("email,full_name")
 
 ## TODOS
 - Improve search filter by specifying fields to filter from
-- Add support for accepting a dataset url rather than just a local file path
-- Add support for accepting raw json data
 - Add CRUD support to the dataset
-- Optimise the search function by implimenting indeces
+- Optimise the search function by implementing indeces 
 - Optimise the loader by chunking the data
 
 ## Contributing

--- a/flexi-json.gemspec
+++ b/flexi-json.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/GD-Personal/flexi-json"
-  spec.metadata["changelog_uri"] = "https://github.com/GD-Personal/flexi/blob/main/CHANGELOG"
+  spec.metadata["changelog_uri"] = "https://github.com/GD-Personal/flexi-json/blob/main/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/lib/flexi/json.rb
+++ b/lib/flexi/json.rb
@@ -10,7 +10,7 @@ module Flexi::Json
 
   class Run
     # Your code goes here...
-    def initialize(data, options = {})
+    def initialize(data)
       @json_data = Flexi::Json::Loader.new(data).load_data
     end
 

--- a/lib/flexi/json/loader.rb
+++ b/lib/flexi/json/loader.rb
@@ -1,19 +1,40 @@
+require "net/http"
+require "uri"
+
 module Flexi
   module Json
     class Loader
-      def initialize(data_file_path)
-        @data_file_path = data_file_path
+      def initialize(data)
+        @data = data
       end
 
-      def load_data(output = $stdout)
-        file = File.read(@data_file_path)
-        JSON.parse(file).map { |result| Dataset.new(result) }
-      rescue Errno::ENOENT
-        output.puts("Dataset file not found at #{@data_file_path}!")
-        []
-      rescue JSON::ParserError
-        output.puts("Invalid JSON!")
-        []
+      def load_data
+        loaded_data = load_from_local_file || load_from_raw_json || load_from_url || []
+        loaded_data.map { |result| Dataset.new(result.transform_keys(&:to_sym)) }
+      end
+
+      private
+
+      def load_from_raw_json(raw_json = nil)
+        data = JSON.parse(raw_json || @data)
+        data.is_a?(Array) ? data : [data]
+      rescue JSON::ParserError, TypeError
+        nil
+      end
+
+      def load_from_local_file
+        data = File.read(@data)
+        load_from_raw_json(data)
+      rescue Errno::ENOENT, TypeError
+        nil
+      end
+
+      def load_from_url
+        uri = URI.parse(@data)
+        response = Net::HTTP.get_response(uri)
+        response.is_a?(Net::HTTPSuccess) ? load_from_raw_json(response.body) : nil
+      rescue URI::InvalidURIError, Errno::ECONNREFUSED
+        nil
       end
     end
   end

--- a/lib/flexi/json/searcher.rb
+++ b/lib/flexi/json/searcher.rb
@@ -22,7 +22,7 @@ module Flexi
         return [] if filtered_fields.empty?
 
         grouped_data = @data.group_by do |d|
-          filtered_fields.map { |f| d.attributes[f].to_s.downcase }
+          filtered_fields.map { |f| d.attributes[f.to_sym].to_s.downcase }
         end
         grouped_data.each do |key, value|
           duplicates[key] = value if value.size > 1

--- a/spec/flexi/json/loader_spec.rb
+++ b/spec/flexi/json/loader_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+require "json"
+
+RSpec.describe Flexi::Json::Loader do
+  describe "#load_data" do
+    subject { described_class.new(dataset).load_data }
+
+    context "for a given data" do
+      context "which is a local file path" do
+        let(:dataset) { "./spec/data/dataset.json" }
+        it "loads the dataset" do
+          expect(subject).not_to eq []
+          expect(subject.first.class).to eq Flexi::Json::Dataset
+        end
+      end
+
+      context "which is a non-existent file path" do
+        let(:dataset) { "./spec/data/nonexistent.json" }
+        it "returns an empty result" do
+          expect(subject).to eq []
+        end
+      end
+
+      context "which is a valid json object" do
+        let(:dataset) { {name: "John", address: "Sydney Australia"}.to_json }
+        it "loads the dataset" do
+          expect(subject).not_to eq []
+          expect(subject.first.class).to eq Flexi::Json::Dataset
+        end
+      end
+
+      context "which is an invalid json object" do
+        let(:dataset) { {name: "John", address: "Sydney Australia"} }
+        it "rturns an empty result" do
+          expect(subject).to eq []
+        end
+      end
+
+      context "which is url to a json data" do
+        let(:dataset) { "https://raw.githubusercontent.com/GD-Personal/flexi-json/main/spec/data/dataset.json" }
+        it "works" do
+          expect(subject).not_to eq []
+          expect(subject.first.class).to eq Flexi::Json::Dataset
+        end
+      end
+
+      context "which is url to an invalid json data" do
+        let(:dataset) { "https://raw.githubusercontent.com/GD-Personal/flexi-json/main/spec/data/dataset.csv" }
+        it "works and returns []" do
+          expect(subject).to eq []
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, the Flexi::Json::Loader can only be initialized with a path to a local json file. We want to add more flexibility into this class by having the ability to pass different parameters such as: 
1. a json data
2. a url to a json data,
3. and a path to a local json file.