### PR TITLE
Config Options

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flexi-json (0.3.0)
+    flexi-json (0.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -54,8 +54,15 @@ flexi_json.search({first_name: "john", address: "sydney"}, options)
 # => [#<Flexi::Json::Dataset:0x0000ffffa0f5f668 @address="Sydney Australia", @attributes={:name=>"John", :address=>"Sydney Australia"}, @name="John", @searchable_fields=["name", "address"]>]
 ```
 
+## Configuration
+```ruby
+Flexi::Json.configure do |config|
+  config.exact_match_search = true
+  config.match_all_fields = true
+end
+```
+
 ## TODOS
-- Improve search filter by specifying fields to filter from
 - Add CRUD support to the dataset
 - Optimise the search function by implementing indeces 
 - Optimise the loader by chunking the data

--- a/lib/flexi/json.rb
+++ b/lib/flexi/json.rb
@@ -1,12 +1,25 @@
 # frozen_string_literal: true
 
+require_relative "json/configuration"
 require_relative "json/dataset"
 require_relative "json/loader"
 require_relative "json/searcher"
 require_relative "json/version"
 
 module Flexi::Json
-  class Error < StandardError; end
+  class << self
+    attr_writer :configuration
+
+    # Access or initialize the configuration object
+    def configuration
+      @configuration ||= Flexi::Json::Configuration.new
+    end
+
+    # Configure block for setting custom configurations
+    def configure
+      yield(configuration)
+    end
+  end
 
   class Run
     # Your code goes here...
@@ -21,10 +34,6 @@ module Flexi::Json
 
     def find_duplicates(keys)
       @searcher.find_duplicates(keys)
-    end
-
-    def display_results
-      @searcher.display_results
     end
   end
 end

--- a/lib/flexi/json.rb
+++ b/lib/flexi/json.rb
@@ -12,7 +12,7 @@ module Flexi::Json
 
     # Access or initialize the configuration object
     def configuration
-      @configuration ||= Flexi::Json::Configuration.new
+      @configuration ||= Flexi::Json::Configuration.instance
     end
 
     # Configure block for setting custom configurations

--- a/lib/flexi/json/configuration.rb
+++ b/lib/flexi/json/configuration.rb
@@ -11,8 +11,8 @@ module Flexi
       class << self
         def default_match_options
           {
-            matched_all: @match_all_fields,
-            exact_match: @exact_match_search
+            match_all: @match_all_fields || false,
+            exact_match: @exact_match_search || false
           }.freeze
         end
       end
@@ -21,7 +21,6 @@ module Flexi
         @exact_match_search = false
         @match_all_fields = false
       end
-
     end
   end
 end

--- a/lib/flexi/json/configuration.rb
+++ b/lib/flexi/json/configuration.rb
@@ -1,0 +1,27 @@
+require "singleton"
+module Flexi
+  module Json
+    class ConfigError < StandardError; end
+
+    class Configuration
+      include Singleton
+
+      attr_accessor :exact_match_search, :match_all_fields
+
+      class << self
+        def default_match_options
+          {
+            matched_all: @match_all_fields,
+            exact_match: @exact_match_search
+          }.freeze
+        end
+      end
+
+      def initialize
+        @exact_match_search = false
+        @match_all_fields = false
+      end
+
+    end
+  end
+end

--- a/lib/flexi/json/dataset.rb
+++ b/lib/flexi/json/dataset.rb
@@ -18,7 +18,7 @@ module Flexi
 
         return false if valid_fields.empty?
 
-        matching_method = options[:matched_all] ? :all? : :any?
+        matching_method = options[:match_all] ? :all? : :any?
         valid_fields.public_send(matching_method) do |field|
           search_query = query.is_a?(Hash) ? query[field.to_sym] : query
           if options[:exact_match]

--- a/lib/flexi/json/dataset.rb
+++ b/lib/flexi/json/dataset.rb
@@ -1,4 +1,3 @@
-require "debug"
 module Flexi
   module Json
     class Dataset
@@ -13,7 +12,7 @@ module Flexi
         end
       end
 
-      def matches?(query, fields = searchable_fields, options: Searcher::DEFAULT_MATCH_OPTIONS)
+      def matches?(query, fields = searchable_fields, options: Flexi::Json::Configuration.default_match_options)
         validateable_fields = query.is_a?(Hash) ? query.keys.map(&:to_s) : fields
         valid_fields = validateable_fields&.select { |field| searchable_fields.include?(field) } || searchable_fields
 

--- a/lib/flexi/json/searcher.rb
+++ b/lib/flexi/json/searcher.rb
@@ -5,11 +5,6 @@ module Flexi
     class Searcher
       attr_reader :data, :result
 
-      DEFAULT_MATCH_OPTIONS = {
-        matched_all: false,
-        exact_match: false
-      }.freeze
-
       def initialize(data)
         @data = data
         @result = []

--- a/lib/flexi/json/version.rb
+++ b/lib/flexi/json/version.rb
@@ -2,6 +2,6 @@
 
 module Flexi
   module Json
-    VERSION = "0.3.0"
+    VERSION = "0.4.0"
   end
 end

--- a/spec/flexi/json/configuration_spec.rb
+++ b/spec/flexi/json/configuration_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.describe Flexi::Json::Configuration do
+  subject { described_class.instance }
+  describe "#initialize" do
+    it "sets the default configurations" do
+      expect(subject.exact_match_search).to eq false
+      expect(subject.match_all_fields).to eq false
+    end
+  end
+
+  describe "#default_match_options" do
+    it "returns the default match settings" do
+      expectation = {match_all: false, exact_match: false}
+      expect(described_class.default_match_options).to match(expectation)
+    end
+  end
+end

--- a/spec/flexi/json/dataset_spec.rb
+++ b/spec/flexi/json/dataset_spec.rb
@@ -106,17 +106,17 @@ RSpec.describe Flexi::Json::Dataset do
         end
       end
 
-      context "when matched_all option is true" do
+      context "when match_all option is true" do
         it "returns a match" do
-          expect(subject.matches?({full_name: "john"}, options: {matched_all: true})).to eq true
-          expect(subject.matches?({full_name: "john", email: "john.doe@gmail.com"}, options: {matched_all: true})).to eq true
-          expect(subject.matches?({full_name: "john", email: "maryjane@gmail.com"}, options: {matched_all: true})).to eq false
+          expect(subject.matches?({full_name: "john"}, options: {match_all: true})).to eq true
+          expect(subject.matches?({full_name: "john", email: "john.doe@gmail.com"}, options: {match_all: true})).to eq true
+          expect(subject.matches?({full_name: "john", email: "maryjane@gmail.com"}, options: {match_all: true})).to eq false
         end
       end
 
-      context "when matched_all option is false" do
+      context "when match_all option is false" do
         it "returns a valid match" do
-          expect(subject.matches?({full_name: "john", email: "maryjane@gmail.com"}, options: {matched_all: false})).to eq true
+          expect(subject.matches?({full_name: "john", email: "maryjane@gmail.com"}, options: {match_all: false})).to eq true
         end
       end
 
@@ -128,12 +128,12 @@ RSpec.describe Flexi::Json::Dataset do
         end
       end
 
-      context "when exact_match and matched_all option is set" do
+      context "when exact_match and match_all option is set" do
         it "returns a valid match" do
-          expect(subject.matches?({full_name: "john", email: "maryjane@gmail.com"}, options: {exact_match: true, matched_all: true})).to eq false
-          expect(subject.matches?({full_name: "john doe", email: "maryjane@gmail.com"}, options: {exact_match: true, matched_all: true})).to eq false
-          expect(subject.matches?({full_name: "john", email: "john.doe@gmail.com"}, options: {exact_match: true, matched_all: true})).to eq false
-          expect(subject.matches?({full_name: "john doe", email: "john.doe@gmail.com"}, options: {exact_match: true, matched_all: true})).to eq true
+          expect(subject.matches?({full_name: "john", email: "maryjane@gmail.com"}, options: {exact_match: true, match_all: true})).to eq false
+          expect(subject.matches?({full_name: "john doe", email: "maryjane@gmail.com"}, options: {exact_match: true, match_all: true})).to eq false
+          expect(subject.matches?({full_name: "john", email: "john.doe@gmail.com"}, options: {exact_match: true, match_all: true})).to eq false
+          expect(subject.matches?({full_name: "john doe", email: "john.doe@gmail.com"}, options: {exact_match: true, match_all: true})).to eq true
         end
       end
 

--- a/spec/flexi/json_spec.rb
+++ b/spec/flexi/json_spec.rb
@@ -4,4 +4,34 @@ RSpec.describe Flexi::Json do
   it "has a version number" do
     expect(Flexi::Json::VERSION).not_to be nil
   end
+
+  describe ".configuration" do
+    it "sets the configuration object" do
+      expect(described_class.configuration.class).to eq Flexi::Json::Configuration
+    end
+
+    context "for default configs" do
+      it "returns the default configurations" do
+        expect(described_class.configuration.exact_match_search).to eq false
+        expect(described_class.configuration.match_all_fields).to eq false
+      end
+    end
+  end
+
+  describe ".configure" do
+    context "when yielded" do
+      subject do
+        described_class.configure do |config|
+          config.exact_match_search = true
+          config.match_all_fields = true
+        end
+        described_class
+      end
+
+      it "returns the correct configurations" do
+        expect(subject.configuration.exact_match_search).to eq true
+        expect(subject.configuration.match_all_fields).to eq true
+      end
+    end
+  end
 end


### PR DESCRIPTION
- We are adding support to easily configured the gem's default options such as the search types' exact_match and match_all.
- We have also rename the `matched_all` option to `match_all`.